### PR TITLE
docs(claude): TypeScript Exemptions table for documented TS files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,3 +82,15 @@ Both are FOSS with independent governance (no Big Tech).
 - SHA-pinned dependencies
 - SPDX license headers on all files
 
+### TypeScript Exemptions (Approved)
+
+The hyperpolymath "no new TypeScript" policy has the following approved exemptions in this repo. These are *not* policy violations — they are documented carve-outs.
+
+| Path | Files | Rationale | Unblock condition |
+|---|---|---|---|
+| `src/wasm-bridge.ts` | 1 | Explicit FFI bridge between TS host and WASM core; thin glue, no application logic. | AffineScript first-class WASM-direct invocation surface. |
+| `src/rescript-bridge.ts` | 1 | Explicit bridge between TS host and ReScript layer; thin glue. | Replace ReScript layer with AffineScript core (then bridge dissolves). |
+| `src/storage.ts` | 1 | Deno-runtime storage interface (KV/Deno.openKv); ecosystem is Deno-native. | AffineScript Deno KV bindings. |
+| `src/observability.ts` | 1 | Deno-runtime observability — OpenTelemetry exporters and Deno.metrics. | AffineScript OTel bindings (post Node-target #35). |
+
+Adding to this list requires explicit user approval and an unblock condition. New TypeScript files outside this list are blocked by the RSR antipattern check.


### PR DESCRIPTION
Adds a documented `TypeScript Exemptions` section to `.claude/CLAUDE.md`, mirroring the affinescript / standards / my-lang / boj-server pattern.

The new RSR antipattern check (deployed estate-wide) reads this table at CI time. Each row covers a path with rationale + unblock condition, so the exemption is visible and audit-friendly.

This is the documented carve-out for files that legitimately can't be AffineScript today (Node/Deno-runtime, no AffineScript binding, port-in-progress, etc.). Migrating any individual file just removes the corresponding row.