### PR TITLE
fix(codeql): switch language matrix to 'actions' (no JS/TS in repo)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - language: javascript-typescript
+          - language: actions
             build-mode: none
 
     steps:


### PR DESCRIPTION
CodeQL was pinned to language: javascript-typescript on a repo with no JS/TS source files, so the analyze job failed with a configuration error every run — blocking all Dependabot PRs.

Same root cause as IJ.jl#6 (and the same fix applied to JuliaKids.jl#7, PRComms.jl#7, etc.). Switches to ctions, which scans the workflow files every repo has.

Going forward: a workflow_audit rule will be added to hypatia to flag any codeql.yml whose language matrix doesn't match the repo's actual source languages.