### PR TITLE
ci: repin denoland/setup-deno to a resolvable SHA (v2.0.4)

### DIFF
--- a/.github/workflows/rescript-deno-ci.yml
+++ b/.github/workflows/rescript-deno-ci.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: denoland/setup-deno@5fae568d37bbd5d82f7bc6ead283828a72525312 # v2.0.0
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v1.x
       
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: denoland/setup-deno@5fae568d37bbd5d82f7bc6ead283828a72525312 # v2.0.0
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
       - name: Check permissions
         run: |
           # Audit for dangerous permissions


### PR DESCRIPTION
ci: repin denoland/setup-deno to a resolvable SHA (v2.0.4)

`ReScript/Deno CI` was failing at "Set up job", before any code ran:

    Unable to resolve action `denoland/setup-deno@5fae568d...`,
    unable to find version `5fae568d37bbd5d82f7bc6ead283828a72525312`

The pinned SHA (commented `# v2.0.0`) is no longer resolvable (yanked /
non-existent ref). Repin both occurrences to the current release:
`denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282`
(= tag v2.0.4), keeping the org's full-length-SHA pin policy.

Pre-existing infra rot, unrelated to the source migration (#31/#33);
this was just the only source-side-fixable red. Other red main checks
(GitHub Pages, Finishingbot, Seambot, Mirror, Rhodibot, CodeQL) are
org-level infra (missing bot/PAT/Radicle secrets; CodeQL `actions`
lane needs GHAS; an action in the Pages reusable chain not SHA-pinned)
— not fixable by a source PR here.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
