### PR TITLE
ci: fix Mirror-to-Radicle dir + bump codeql-action to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,12 +30,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@662472033e021d55d94146f66f6058822b0b39fd # v3.28.1
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v3.28.1
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -140,6 +140,7 @@ jobs:
 
       - name: Mirror to Radicle
         run: |
+          mkdir -p ~/.radicle/keys
           echo "${{ secrets.RADICLE_KEY }}" > ~/.radicle/keys/radicle
           chmod 600 ~/.radicle/keys/radicle
           rad sync --announce || echo "Radicle sync attempted"


### PR DESCRIPTION
ci: fix Mirror-to-Radicle dir + bump codeql-action to v3

Two pre-existing red main checks, both in-repo workflow bugs (not
secrets, not source):

- mirror.yml "Mirror to Radicle": wrote the key to
  ~/.radicle/keys/radicle before that directory existed
  (`No such file or directory`). RADICLE_KEY secret is already
  configured — add `mkdir -p ~/.radicle/keys` before the write.

- codeql.yml: pinned at github/codeql-action @v3.28.1 which rejected
  the `actions` language ("Did not recognize the following languages:
  actions"). Bump init + analyze to the maintained v3 major
  (458d36d7d4f47d0dd16ca424c1d3cda0060f1360 # v3), which supports the
  GitHub Actions CodeQL language; SHA-pinned per org policy.

Unrelated to the #122/#30 source migration; clears two pre-existing
estate-infra reds with no behaviour change to ubicity itself.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
