### PR TITLE
ci: disable phantom-bot workflows until bot repos exist

### DIFF
--- a/.github/workflows/finishingbot.yml
+++ b/.github/workflows/finishingbot.yml
@@ -16,6 +16,10 @@ on:
 
 jobs:
   release-readiness:
+    # TODO: disabled — hyperpolymath/finishing-bot does not exist yet
+    # (the clone step targets a phantom repo, so this can never pass).
+    # Re-enable (remove `if: false`) once the bot repo is created/restored.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4

--- a/.github/workflows/rhodibot.yml
+++ b/.github/workflows/rhodibot.yml
@@ -16,6 +16,10 @@ on:
 
 jobs:
   rsr-compliance:
+    # TODO: disabled — hyperpolymath/rhodibot does not exist yet
+    # (the clone step targets a phantom repo, so this can never pass).
+    # Re-enable (remove `if: false`) once the bot repo is created/restored.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4

--- a/.github/workflows/seambot.yml
+++ b/.github/workflows/seambot.yml
@@ -16,6 +16,10 @@ on:
 
 jobs:
   seam-health:
+    # TODO: disabled — hyperpolymath/seambot does not exist yet
+    # (the clone step targets a phantom repo, so this can never pass).
+    # Re-enable (remove `if: false`) once the bot repo is created/restored.
+    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4


### PR DESCRIPTION
ci: disable phantom-bot workflows until the bot repos exist

finishingbot/seambot/rhodibot each `git clone
https://github.com/hyperpolymath/<bot>.git`, but none of those repos
exist (verified: not under hyperpolymath or metadatastician; estate
search empty; auth confirmed working). So these checks can never pass
and were permanent red on every push, unrelated to source.

Gate each job behind `if: false` with a TODO (not deleted — the
scaffolding is intentional; "Part of gitbot-fleet"). Re-enable by
removing `if: false` once the bot repos are created/restored.

Pre-existing estate-infra drift; no behaviour change to ubicity.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
