### PR TITLE
ci(pages): replace upload-pages-artifact composite with explicit SHA-pinned upload

### DIFF
--- a/.github/workflows/casket-pages.yml
+++ b/.github/workflows/casket-pages.yml
@@ -99,10 +99,29 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
+      # NOTE: actions/upload-pages-artifact is a composite that internally
+      # calls actions/upload-artifact@v4 (an UNPINNED upstream tag). The
+      # org ruleset enforces "all actions pinned to a full-length SHA"
+      # recursively, so the nested unpinned tag fails the check even
+      # though our workflow pins everything. Replicate the composite's
+      # behaviour explicitly with a SHA-pinned actions/upload-artifact
+      # (same SHA already used elsewhere in this repo): tar the site as
+      # deploy-pages expects (artifact name `github-pages`).
+      - name: Archive site as the github-pages artifact
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory _site \
+            -cvf "${RUNNER_TEMP}/artifact.tar" \
+            --exclude=.git --exclude=.github \
+            .
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          path: '_site'
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     environment:


### PR DESCRIPTION
ci(pages): replace upload-pages-artifact composite with explicit SHA-pinned upload

`GitHub Pages` (casket-pages.yml) failed the org "all actions pinned to
a full-length commit SHA" ruleset with:

    actions/upload-artifact@v4 is not allowed … must be pinned to a
    full-length commit SHA

casket-pages.yml itself already pins every action. The violation is
*transitive*: `actions/upload-pages-artifact@v3` is a composite action
whose own action.yml does `uses: actions/upload-artifact@v4` (an
unpinned upstream moving tag) — and the ruleset evaluates nested
actions recursively, which we cannot pin from our side.

Fix: drop the composite and do exactly what it does, with a
SHA-pinned primitive — tar `_site` the way `actions/deploy-pages`
expects and upload it as the `github-pages` artifact via
`actions/upload-artifact@ea165f8d… # v4` (the same SHA already pinned
elsewhere in this repo). `configure-pages` / `deploy-pages` stay
(already pinned; they don't nest an unpinned upload-artifact).

No behaviour change to the published site; removes the only remaining
policy-blocked red. Pre-existing infra, unrelated to the #122/#30
source migration.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
