### PR TITLE
fix(ci): re-enable finishingbot/seambot/rhodibot via gitbot-fleet (Refs #37)

### DIFF
--- a/.github/workflows/finishingbot.yml
+++ b/.github/workflows/finishingbot.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: PMPL-1.0-or-later
 # Finishingbot - Release readiness validation
-# Part of gitbot-fleet
+# Part of gitbot-fleet (hyperpolymath/gitbot-fleet :: bots/finishingbot)
 
 name: Finishingbot Release Check
 
@@ -14,12 +14,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Pinned gitbot-fleet commit. Bump in lockstep when the fleet changes.
+  GITBOT_FLEET_REF: 2e0ea3ca67821a91e650f51bf48a6cfd1c7aae1c
+
 jobs:
   release-readiness:
-    # TODO: disabled — hyperpolymath/finishing-bot does not exist yet
-    # (the clone step targets a phantom repo, so this can never pass).
-    # Re-enable (remove `if: false`) once the bot repo is created/restored.
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
@@ -31,19 +31,29 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
+        with:
+          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/finishingbot
 
-      - name: Clone finishing-bot
+      - name: Fetch gitbot-fleet at pinned ref
         run: |
-          git clone https://github.com/hyperpolymath/finishing-bot.git /tmp/finishing-bot
-          cd /tmp/finishing-bot
-          cargo build --release
+          git clone --no-checkout --filter=tree:0 \
+            https://github.com/hyperpolymath/gitbot-fleet.git \
+            "$RUNNER_TEMP/gitbot-fleet"
+          git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
+      - name: Build finishingbot
+        working-directory: ${{ runner.temp }}/gitbot-fleet/bots/finishingbot
+        env:
+          OPENSSL_NO_VENDOR: 1
+        run: cargo build --release
 
       - name: Run finishingbot audit
         id: finishingbot
         continue-on-error: true
         run: |
-          cd ${{ github.workspace }}
-          /tmp/finishing-bot/target/release/finishingbot audit > finishingbot-results.txt 2>&1
+          # The finishingbot crate's binary is `finishing-bot` (hyphenated).
+          "$RUNNER_TEMP/gitbot-fleet/bots/finishingbot/target/release/finishing-bot" \
+            --path "$GITHUB_WORKSPACE" audit > finishingbot-results.txt 2>&1
           echo $? > finishingbot-exit-code.txt
 
       - name: Display results

--- a/.github/workflows/rhodibot.yml
+++ b/.github/workflows/rhodibot.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: PMPL-1.0-or-later
 # Rhodibot - RSR compliance checking
-# Part of gitbot-fleet
+# Part of gitbot-fleet (hyperpolymath/gitbot-fleet :: bots/rhodibot)
 
 name: Rhodibot RSR Compliance
 
@@ -14,12 +14,13 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Pinned gitbot-fleet commit. Must include the `rhodibot check` CLI
+  # subcommand (gitbot-fleet#150). Bump in lockstep when the fleet changes.
+  GITBOT_FLEET_REF: 2e0ea3ca67821a91e650f51bf48a6cfd1c7aae1c
+
 jobs:
   rsr-compliance:
-    # TODO: disabled — hyperpolymath/rhodibot does not exist yet
-    # (the clone step targets a phantom repo, so this can never pass).
-    # Re-enable (remove `if: false`) once the bot repo is created/restored.
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
@@ -31,20 +32,34 @@ jobs:
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
+        with:
+          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/rhodibot
 
-      - name: Clone rhodibot
+      - name: Fetch gitbot-fleet at pinned ref
         run: |
-          git clone https://github.com/hyperpolymath/rhodibot.git /tmp/rhodibot
-          cd /tmp/rhodibot
-          cargo build --release
+          git clone --no-checkout --filter=tree:0 \
+            https://github.com/hyperpolymath/gitbot-fleet.git \
+            "$RUNNER_TEMP/gitbot-fleet"
+          git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
+      - name: Build rhodibot
+        working-directory: ${{ runner.temp }}/gitbot-fleet/bots/rhodibot
+        env:
+          OPENSSL_NO_VENDOR: 1
+        run: cargo build --release
 
       - name: Run rhodibot check
         id: rhodibot
         continue-on-error: true
+        env:
+          # Public-repo read via the GitHub REST API; the built-in,
+          # read-only workflow token is sufficient (no PAT needed).
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          /tmp/rhodibot/target/release/rhodibot check \
-            --owner ${{ github.repository_owner }} \
-            --repo ${{ github.event.repository.name }} > rhodibot-results.txt 2>&1
+          "$RUNNER_TEMP/gitbot-fleet/bots/rhodibot/target/release/rhodibot" check \
+            --owner "${{ github.repository_owner }}" \
+            --repo "${{ github.event.repository.name }}" \
+            > rhodibot-results.txt 2>&1
           echo $? > rhodibot-exit-code.txt
 
       - name: Display results

--- a/.github/workflows/seambot.yml
+++ b/.github/workflows/seambot.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: PMPL-1.0-or-later
 # Seambot - Seam hygiene and integration health
-# Part of gitbot-fleet
+# Part of gitbot-fleet (hyperpolymath/gitbot-fleet :: bots/seambot)
 
 name: Seambot Integration Health
 
@@ -14,29 +14,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  # Pinned gitbot-fleet commit. Bump in lockstep when the fleet changes.
+  GITBOT_FLEET_REF: 2e0ea3ca67821a91e650f51bf48a6cfd1c7aae1c
+
 jobs:
   seam-health:
-    # TODO: disabled — hyperpolymath/seambot does not exist yet
-    # (the clone step targets a phantom repo, so this can never pass).
-    # Re-enable (remove `if: false`) once the bot repo is created/restored.
-    if: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
-        with:
-          toolchain: stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
-
-      - name: Clone seambot
-        run: |
-          git clone https://github.com/hyperpolymath/seambot.git /tmp/seambot
-          cd /tmp/seambot
-          cargo build --release
 
       - name: Check for seam register
         id: check-seam
@@ -47,12 +33,40 @@ jobs:
             echo "has_seam=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Rust toolchain
+        if: steps.check-seam.outputs.has_seam == 'true'
+        uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b  # stable
+        with:
+          toolchain: stable
+
+      - name: Cache dependencies
+        if: steps.check-seam.outputs.has_seam == 'true'
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
+        with:
+          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/seambot
+
+      - name: Fetch gitbot-fleet at pinned ref
+        if: steps.check-seam.outputs.has_seam == 'true'
+        run: |
+          git clone --no-checkout --filter=tree:0 \
+            https://github.com/hyperpolymath/gitbot-fleet.git \
+            "$RUNNER_TEMP/gitbot-fleet"
+          git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
+      - name: Build seambot
+        if: steps.check-seam.outputs.has_seam == 'true'
+        working-directory: ${{ runner.temp }}/gitbot-fleet/bots/seambot
+        env:
+          OPENSSL_NO_VENDOR: 1
+        run: cargo build --release
+
       - name: Run seambot check
         if: steps.check-seam.outputs.has_seam == 'true'
         id: seambot
         continue-on-error: true
         run: |
-          /tmp/seambot/target/release/seambot check > seambot-results.txt 2>&1
+          "$RUNNER_TEMP/gitbot-fleet/bots/seambot/target/release/seambot" check \
+            > seambot-results.txt 2>&1
           echo $? > seambot-exit-code.txt
 
       - name: Display results


### PR DESCRIPTION
## Summary

Re-enables the three bot checks disabled in #36. They were permanent
false-red because they cloned **phantom repos** (`hyperpolymath/finishing-bot`,
`/seambot`, `/rhodibot`) that never existed. The bots actually live in
**`hyperpolymath/gitbot-fleet`** under `bots/`.

Each workflow now: clones `gitbot-fleet` at a **pinned commit** (partial
clone + checkout SHA), builds the specific bot crate, runs the **correct
binary**, then the `if: false` guard is removed.

| Bot | Root cause fixed | Invocation |
|---|---|---|
| finishingbot | phantom clone **+ wrong binary name** (`finishingbot` → crate binary is `finishing-bot`) | `finishing-bot --path "$GITHUB_WORKSPACE" audit` |
| seambot | phantom clone | `seambot check` (keeps the `spec/seams/seam-register.json` guard) |
| rhodibot | phantom clone **+ rhodibot had no CLI** (was webhook-server-only) | `rhodibot check --owner --repo`, built-in read-only `GITHUB_TOKEN` (public repo, no PAT) |

## Dependency

rhodibot needs the new `rhodibot check` subcommand added in
**hyperpolymath/gitbot-fleet#150**. The pinned ref is currently that
PR's branch HEAD (`2e0ea3ca67821a91e650f51bf48a6cfd1c7aae1c`); it will
be **bumped to the post-merge `main` SHA** once #150 lands. Do not merge
this before that bump.

## Tracking

`Refs #37`. Native sub-issues: #39 (seambot), #40 (finishingbot —
binary-name bug), #41 (rhodibot — blocked on gitbot-fleet#150).
Per estate workflow, #37 closes only on explicit joint agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)