### PR TITLE
fix(ci): make finishingbot/seambot/rhodibot workflows actually green

### DIFF
--- a/.github/workflows/finishingbot.yml
+++ b/.github/workflows/finishingbot.yml
@@ -29,17 +29,22 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
-        with:
-          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/finishingbot
-
+      # Clone BEFORE the rust-cache step: rust-cache needs the workspace
+      # (Cargo.lock) to exist to key the cache, and cloning into a
+      # cache-created directory fails with `destination path ... already
+      # exists and is not an empty directory` (exit 128).
       - name: Fetch gitbot-fleet at pinned ref
         run: |
+          rm -rf "$RUNNER_TEMP/gitbot-fleet"
           git clone --no-checkout --filter=tree:0 \
             https://github.com/hyperpolymath/gitbot-fleet.git \
             "$RUNNER_TEMP/gitbot-fleet"
           git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
+        with:
+          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/finishingbot
 
       - name: Build finishingbot
         working-directory: ${{ runner.temp }}/gitbot-fleet/bots/finishingbot
@@ -52,9 +57,15 @@ jobs:
         continue-on-error: true
         run: |
           # The finishingbot crate's binary is `finishing-bot` (hyphenated).
+          # A non-zero audit is the intended gating signal. Capture it
+          # without letting `set -e` abort the step before the exit-code
+          # file is written, then re-exit with it so this step's outcome
+          # is `failure` and the "Fail on …findings" step below triggers.
+          rc=0
           "$RUNNER_TEMP/gitbot-fleet/bots/finishingbot/target/release/finishing-bot" \
-            --path "$GITHUB_WORKSPACE" audit > finishingbot-results.txt 2>&1
-          echo $? > finishingbot-exit-code.txt
+            --path "$GITHUB_WORKSPACE" audit > finishingbot-results.txt 2>&1 || rc=$?
+          echo "$rc" > finishingbot-exit-code.txt
+          exit "$rc"
 
       - name: Display results
         if: always()
@@ -65,7 +76,7 @@ jobs:
             cat finishingbot-results.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
 
-            exit_code=$(cat finishingbot-exit-code.txt)
+            exit_code=$(cat finishingbot-exit-code.txt 2>/dev/null || echo unknown)
             if [ "$exit_code" = "0" ]; then
               echo "✅ Release readiness checks passed" >> $GITHUB_STEP_SUMMARY
             else

--- a/.github/workflows/rhodibot.yml
+++ b/.github/workflows/rhodibot.yml
@@ -30,17 +30,22 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
-        with:
-          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/rhodibot
-
+      # Clone BEFORE the rust-cache step: rust-cache needs the workspace
+      # (Cargo.lock) to exist to key the cache, and cloning into a
+      # cache-created directory fails with `destination path ... already
+      # exists and is not an empty directory` (exit 128).
       - name: Fetch gitbot-fleet at pinned ref
         run: |
+          rm -rf "$RUNNER_TEMP/gitbot-fleet"
           git clone --no-checkout --filter=tree:0 \
             https://github.com/hyperpolymath/gitbot-fleet.git \
             "$RUNNER_TEMP/gitbot-fleet"
           git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
+        with:
+          workspaces: ${{ runner.temp }}/gitbot-fleet/bots/rhodibot
 
       - name: Build rhodibot
         working-directory: ${{ runner.temp }}/gitbot-fleet/bots/rhodibot
@@ -56,11 +61,17 @@ jobs:
           # read-only workflow token is sufficient (no PAT needed).
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          # A non-zero check is the intended gating signal. Capture it
+          # without letting `set -e` abort the step before the exit-code
+          # file is written, then re-exit with it so this step's outcome
+          # is `failure` and the "Fail on …violations" step below triggers.
+          rc=0
           "$RUNNER_TEMP/gitbot-fleet/bots/rhodibot/target/release/rhodibot" check \
             --owner "${{ github.repository_owner }}" \
             --repo "${{ github.event.repository.name }}" \
-            > rhodibot-results.txt 2>&1
-          echo $? > rhodibot-exit-code.txt
+            > rhodibot-results.txt 2>&1 || rc=$?
+          echo "$rc" > rhodibot-exit-code.txt
+          exit "$rc"
 
       - name: Display results
         if: always()
@@ -71,7 +82,7 @@ jobs:
             cat rhodibot-results.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
 
-            exit_code=$(cat rhodibot-exit-code.txt)
+            exit_code=$(cat rhodibot-exit-code.txt 2>/dev/null || echo unknown)
             if [ "$exit_code" = "0" ]; then
               echo "✅ RSR compliance checks passed" >> $GITHUB_STEP_SUMMARY
             else

--- a/.github/workflows/seambot.yml
+++ b/.github/workflows/seambot.yml
@@ -39,19 +39,24 @@ jobs:
         with:
           toolchain: stable
 
+      # Clone BEFORE the rust-cache step: rust-cache needs the workspace
+      # (Cargo.lock) to exist to key the cache, and cloning into a
+      # cache-created directory fails with `destination path ... already
+      # exists and is not an empty directory` (exit 128).
+      - name: Fetch gitbot-fleet at pinned ref
+        if: steps.check-seam.outputs.has_seam == 'true'
+        run: |
+          rm -rf "$RUNNER_TEMP/gitbot-fleet"
+          git clone --no-checkout --filter=tree:0 \
+            https://github.com/hyperpolymath/gitbot-fleet.git \
+            "$RUNNER_TEMP/gitbot-fleet"
+          git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
+
       - name: Cache dependencies
         if: steps.check-seam.outputs.has_seam == 'true'
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db  # v2
         with:
           workspaces: ${{ runner.temp }}/gitbot-fleet/bots/seambot
-
-      - name: Fetch gitbot-fleet at pinned ref
-        if: steps.check-seam.outputs.has_seam == 'true'
-        run: |
-          git clone --no-checkout --filter=tree:0 \
-            https://github.com/hyperpolymath/gitbot-fleet.git \
-            "$RUNNER_TEMP/gitbot-fleet"
-          git -C "$RUNNER_TEMP/gitbot-fleet" checkout "$GITBOT_FLEET_REF"
 
       - name: Build seambot
         if: steps.check-seam.outputs.has_seam == 'true'
@@ -65,9 +70,13 @@ jobs:
         id: seambot
         continue-on-error: true
         run: |
+          # A non-zero check is the intended signal; capture it without
+          # letting `set -e` abort before the exit-code file is written.
+          rc=0
           "$RUNNER_TEMP/gitbot-fleet/bots/seambot/target/release/seambot" check \
-            > seambot-results.txt 2>&1
-          echo $? > seambot-exit-code.txt
+            > seambot-results.txt 2>&1 || rc=$?
+          echo "$rc" > seambot-exit-code.txt
+          exit "$rc"
 
       - name: Display results
         if: always() && steps.check-seam.outputs.has_seam == 'true'
@@ -78,7 +87,7 @@ jobs:
             cat seambot-results.txt >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
 
-            exit_code=$(cat seambot-exit-code.txt)
+            exit_code=$(cat seambot-exit-code.txt 2>/dev/null || echo unknown)
             if [ "$exit_code" = "0" ]; then
               echo "✅ All seam checks passed" >> $GITHUB_STEP_SUMMARY
             else


### PR DESCRIPTION
## Problem

The three bot workflows were re-enabled against `gitbot-fleet` in #42, but they were **still red on every run** for two reasons that have nothing to do with the bots themselves (verified from run logs `25977596773`/`777`/`771`):

1. **Step ordering.** `Swatinem/rust-cache` ran *before* the `gitbot-fleet` clone, with `workspaces:` pointing at a path that did not exist yet. rust-cache errored (`The cwd: …/bots/<bot> does not exist!`), the cache never worked, and for **seambot** it left `$RUNNER_TEMP/gitbot-fleet` present so the subsequent `git clone` died with `destination path … already exists and is not an empty directory` (**exit 128**).

2. **Exit-code capture under `set -e`.** `bin … > results.txt 2>&1; echo $? > exit-code.txt` runs under `bash -e`. A non-zero bot exit — which is the *intended gating signal* — aborts the step before the exit-code file is written. The non-`continue-on-error` "Display results" step then hard-fails on the missing file, so the job goes red even though the gate logic was supposed to handle it.

## Fix (all three workflows)

- Clone `gitbot-fleet` **before** the cache step; `rm -rf` the target dir first for idempotency.
- Capture the exit code without aborting, then re-exit with it:
  ```bash
  rc=0
  "$BIN" … > <bot>-results.txt 2>&1 || rc=$?
  echo "$rc" > <bot>-exit-code.txt
  exit "$rc"
  ```
  This preserves the step's `failure` outcome so the `Fail on …findings/violations` gate still fires on real issues, while the job is green only when the bot is genuinely clean.
- Hardened the `Display results` `cat` against a missing file.

## Verification

CLI invocations checked against `gitbot-fleet` @ pinned ref `2e0ea3ca` (which **is** gitbot-fleet#150's commit, so `rhodibot check` exists):

| bot | invocation | clap definition @ ref |
|---|---|---|
| finishingbot | `finishing-bot --path <ws> audit` | global `--path` (default `.`) + `Audit` subcommand ✓ |
| seambot | `seambot check` | global `--path` (default `.`) + `Check` subcommand ✓ |
| rhodibot | `rhodibot check --owner … --repo …` | `Check { owner, repo, format }` (added in #150) ✓ |

All three YAML files validated with `yaml.safe_load`.

Closes #39
Closes #40
Closes #41
Refs #37 (parent — the three sub-issues complete it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)