### PR TITLE
fix(licence): #3 isolated — clear scaffold-placeholder leak (ubicity)

### DIFF
--- a/RSR_OUTLINE.adoc
+++ b/RSR_OUTLINE.adoc
@@ -209,7 +209,7 @@ This template is part of:
 
 == License
 
-SPDX-License-Identifier: PMPL-1.0-or-later-or-later
+SPDX-License-Identifier: PMPL-1.0-or-later
 
 == Links
 

--- a/contractiles/dust/Dustfile
+++ b/contractiles/dust/Dustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Dustfile template - recovery and rollback semantics
 
 version: 1

--- a/contractiles/must/Mustfile
+++ b/contractiles/must/Mustfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: PLMP-1.0-or-later
+# SPDX-License-Identifier: PMPL-1.0-or-later
 # Mustfile - declarative state contract (template)
 # See: https://github.com/hyperpolymath/mustfile
 


### PR DESCRIPTION
#3 isolated pass (pilot #32-shape). Scaffold-placeholder leak per `standards/LICENCE-POLICY.adoc` **A5** — NOT relicensing. -> `PMPL-1.0-or-later`. **3 file(s).** Isolated mode (if dirty) stages ONLY placeholder lines; repo WIP untouched. Gates: per-file clean check, diff-shape asserted, auto-revert on anomaly. 🤖 Generated with [Claude Code](https://claude.com/claude-code)