### PR TITLE
ci: cut Actions burn — scope push triggers + concurrency-cancel

### DIFF
--- a/.github/workflows/rescript-deno-ci.yml
+++ b/.github/workflows/rescript-deno-ci.yml
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: MPL-2.0
 name: ReScript/Deno CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+# Estate guardrail: scope push to default branches so a PR fires once (not
+# push+PR), and cancel superseded runs. Safe — read-only PR-triggered check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Scope `push` to default branches (kills push+PR double-runs) and add `concurrency: cancel-in-progress` to read-only PR-triggered checks. Part of the estate CI-burn reduction (Actions spending-limit wall). Files changed: 1. No SPDX/logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)